### PR TITLE
Add args extraBuildInputs

### DIFF
--- a/templates/common.nix
+++ b/templates/common.nix
@@ -16,7 +16,8 @@
 
   # Arguments
   makeWrapperArgs ? "",
-  precompile ? true
+  precompile ? true,
+  extraBuildInputs ? []
 }:
 
 let
@@ -113,7 +114,7 @@ let
   '';
 
   depot = runCommand "julia-depot" {
-    buildInputs = [git curl julia];
+    buildInputs = [git curl julia] ++ extraBuildInputs;
     inherit registry precompile;
   } ''
     export HOME=$(pwd)

--- a/templates/default.nix
+++ b/templates/default.nix
@@ -1,4 +1,4 @@
-with import <nixpkgs> {};
+{ pkgs ? import <nixpkgs> {} }:
 
 with pkgs;
 
@@ -36,4 +36,7 @@ callPackage ./common.nix {
   # By default, it will just put the new depot at the end of JULIA_DEPOT_PATH.
   # You can add additional flags here.
   makeWrapperArgs = "";
+
+  # Extra Pkgs to precompile environment
+  extraBuildInputs = [];
 }


### PR DESCRIPTION
Fixd some packages missing env such as LIBSVM(gcc9)

Also, nixpkgs-fmt (formatter) here.

![image](https://user-images.githubusercontent.com/21156405/110065072-3b785000-7d23-11eb-8988-905ef81f6996.png)
